### PR TITLE
Change wiki link from fandom to new official wiki link

### DIFF
--- a/src/js/page-functions.js
+++ b/src/js/page-functions.js
@@ -31,7 +31,7 @@ const SYMBOL_ASCENDED = "<i class='reznoricon-ascended'></i>"; // Ascended
 const SYMBOL_RADIANT = "<i class='reznoricon-radiant'></i>"; // Radiant
 const SYMBOL_EMPTY = "<span class='padding-left'></span>"; // No symbol
 const FLEUR_DIVIDE = "<div class='horizontal-line'></div>";
-const WIKI_LINK = "https://hollowknight.fandom.com/wiki/";
+const WIKI_LINK = "https://hollowknight.wiki/w/";
 
 const ROOT = document.documentElement;
 const SCROLL_BUTTON = document.querySelector(".scroll-up-button");


### PR DESCRIPTION
Hey folks, I just changed the base link from the old wiki to the [new official hollow knight wiki](https://hollowknight.wiki/). I tested some links to see if it worked, but I didn't test all of them. I don't know how to run locally though to see if everything works.

Video reference about the transition from fandom to new website [here](https://www.youtube.com/watch?v=qcfuA_UAz3I&t=1204s).